### PR TITLE
Remove Redunant debug statement

### DIFF
--- a/app/Transformers/ErrorTransformer.php
+++ b/app/Transformers/ErrorTransformer.php
@@ -29,12 +29,10 @@ class ErrorTransformer extends TransformerAbstract
         }
 
         if (config('app.debug')) {
-            if (config('app.debug')) {
-                $error['debug'] = [
-                    'exception' => get_class($exception),
-                    'trace' => $this->parseTrace($exception),
-                ];
-            }
+            $error['debug'] = [
+                'exception' => get_class($exception),
+                'trace' => $this->parseTrace($exception),
+            ];
         }
 
         return $error;


### PR DESCRIPTION
The `ìf (config('app.debug'))` is defined 2 times with no reason. What makes that is is redunant. This PR fixes it.