### PR TITLE
Remove gd extension to reduce image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ RUN apk add --no-cache \
     oniguruma-dev \
     mysql-client \
     libxml2-dev \
-    libpng-dev \
-    libjpeg-turbo-dev \
-    freetype-dev \
+    # If you have enabled gd plugin
+    # libpng-dev \
+    # libjpeg-turbo-dev \
+    # freetype-dev \
     git \
-    vim \
     zip \
     unzip \
     curl
@@ -43,8 +43,9 @@ RUN docker-php-ext-install \
     tokenizer \
     xml
 
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
-RUN docker-php-ext-install gd
+# If you need to work with image manipulation.
+# RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+# RUN docker-php-ext-install gd
 
 RUN adduser www-data www-data
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 build: ## Build all Docker images
 	@docker build . --file Dockerfile --tag ${IMAGE_NAME}:latest
 
-up: ## Up all Docker services
+up: ## Start all Docker services
 	@docker-compose up -d
 
 stop: ## Stop all Docker services
@@ -30,5 +30,11 @@ ssh: ## SSH into Docker service app
 composer: ## SSH into a Composer container
 	@docker run --rm -it -v $(PWD):/app composer:2 sh
 
-test: ## Run PHPUnit tests
+dev-test: ## Run test withing Docker-Compose
+	@docker-compose run --rm app vendor/bin/phpunit
+
+install: ## Install Composeer dependencies
+	@docker run --rm -v $(PWD):/app composer:2 composer install
+
+test: build ## Run PHPUnit tests
 	@docker run --rm ${IMAGE_NAME}:latest vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
+            "Database\\Seeders\\": "database/seeders/",
+            "Tests\\": "tests"
         },
         "files": [
             "bootstrap/helpers.php"

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ A starter template to develop API with Lumen 8.
 - Exit from Docker container with `CTRL+C` or `exit`.
 - Rename `docker-compose.local.yaml` to `docker-compose.overridee.yaml`
 - Start the local development server with `make up`.
+- Run tests with `make dev-test`.
 - Run `make` to see available commands.
 
 #### Create new user

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Laravel\Lumen\Testing\DatabaseMigrations;
 use Laravel\Lumen\Testing\DatabaseTransactions;
 
@@ -13,6 +15,6 @@ class ExampleTest extends TestCase
     public function testExample()
     {
         $this->get('/');
-        $this->assertResponseOk();
+        $this->assertResponseStatus(400);
     }
 }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -15,6 +15,6 @@ class ExampleTest extends TestCase
     public function testExample()
     {
         $this->get('/');
-        $this->assertResponseStatus(400);
+        $this->assertResponseOk();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Laravel\Lumen\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
- Comment out `gd` extension in the `Dockerfile`
- Tested CI flow with failed tests.