### PR TITLE
Change image name to fix new image creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: lumen-api-starter-app
     container_name: lumen-api-starter-app
     volumes:
       - app-data:/var/www/html


### PR DESCRIPTION
- Fix the image name in `docker-compose` so the name image created with `make build` command is used for containert.